### PR TITLE
CPU利用率が高くなるバグ修正と少しの機能追加

### DIFF
--- a/Example/DKImagePickerControllerDemo/CustomUIDelegate/CustomUIDelegate.swift
+++ b/Example/DKImagePickerControllerDemo/CustomUIDelegate/CustomUIDelegate.swift
@@ -87,4 +87,7 @@ open class CustomUIDelegate: DKImagePickerControllerBaseUIDelegate {
         return CustomGroupDetailCameraCell.self
     }
 
+    open override func needsToShowImageDetailOnLongPress() -> Bool {
+        false
+    }
 }

--- a/Sources/DKImagePickerController/DKImagePickerControllerBaseUIDelegate.swift
+++ b/Sources/DKImagePickerController/DKImagePickerControllerBaseUIDelegate.swift
@@ -268,6 +268,10 @@ open class DKImagePickerControllerBaseUIDelegate: NSObject, DKImagePickerControl
         return DKAssetGroupCell.self
     }
 
+    open func needsToShowImageDetailOnLongPress() -> Bool {
+        return true
+    }
+
     open func imagePickerControllerSelectGroupButton(_ imagePickerController: DKImagePickerController, selectedGroup: DKAssetGroup) -> UIButton {
         let button = self.createSelectGroupButtonIfNeeded()
         let groupsCount = self.imagePickerController.groupDataManager.groupIds?.count ?? 0

--- a/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -628,6 +628,17 @@ open class DKAssetGroupDetailVC: UIViewController,
         }
     }
 
+    public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        let cell: DKAssetGroupDetailBaseCell
+        if self.isCameraCell(indexPath: indexPath) {
+            cell = self.dequeueReusableCameraCell(for: indexPath)
+        } else {
+            cell = self.dequeueReusableCell(for: indexPath)
+        }
+
+        cell.asset?.cancelRequests()
+    }
+
     public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         guard let imagePickerController = self.imagePickerController else {
             assertionFailure("Expect imagePickerController")

--- a/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -577,11 +577,14 @@ open class DKAssetGroupDetailVC: UIViewController,
                 cell.thumbnailImage = image
             }
         }
-        
-        cell.longPressBlock = { [weak self, weak cell] in
-            guard let strongSelf = self, let strongCell = cell else { return }
-            
-            strongSelf.showGallery(from: strongCell)
+
+        if let imagePickerController = imagePickerController,
+            imagePickerController.UIDelegate.needsToShowImageDetailOnLongPress() {
+
+            cell.longPressBlock = { [weak self, weak cell] in
+                guard let strongSelf = self, let strongCell = cell else { return }
+                strongSelf.showGallery(from: strongCell)
+            }
         }
     }
 


### PR DESCRIPTION
- 画像を押し込んだときに画像の詳細画面に遷移する機能のon/offを切り替えられるようにする
- 高速でスクロールしたときにCPU使用率が高い状態になり、画面がカクカクしてしまう問題の修正